### PR TITLE
Report errors detected in SBML when parsing

### DIFF
--- a/SBMLLint/common/util.py
+++ b/SBMLLint/common/util.py
@@ -86,5 +86,5 @@ def uniqueify(collection):
      
 def checkSBMLDocument(document, model_reference=""): 
   if (document.getNumErrors() > 0):
-    raise ValueError("Errors in SBML document\n%s" 
-        % model_reference)
+    raise ValueError("Errors in SBML document\n%s"
+        % model_reference, document.getErrorLog().toString())

--- a/SBMLLint/tools/sbmllint.py
+++ b/SBMLLint/tools/sbmllint.py
@@ -46,7 +46,7 @@ def lint(model_reference, file_out=sys.stdout,
     xml = util.getXML(model_reference)
     reader = tesbml.SBMLReader()
     document = reader.readSBMLFromString(xml)
-    util.checkSBMLDocument(document)
+    util.checkSBMLDocument(document, model_reference)
     model = document.getModel()
   #
   if mass_balance_check==STRUCTURED_NAMES:


### PR DESCRIPTION
Prior to this change, the checkSBMLDocument function in
SBMLLint/common/util.py would check if the error count during parsing
of the document was non-zero and raise a ValueError if so.  This
change still raises a ValueError, but it adds the contents of
the python-libsml error log to the ValueError to the message
parameter to enable users to identify and correct parsing errors.
In addition, this change modifies the lint function in
SBMLLint/tools/sbmllint.py to pass the name of the SBML file that
is currently being parsed to the call to checkSBMLDocument so that
the ValueError can report the model filename in the expression
parameter, rather than an empty string.